### PR TITLE
Adding Parallel Evaluation mode and MERT embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We have the following metrics in this toolbox:
   - FAD: Frechet audio distance
   - ISc: Inception score
 - Other for references:
-  - FD: Frechet distance, realized by PANNs, a state-of-the-art audio classification model
+  - FD: Frechet distance, realized by either PANNs, a state-of-the-art audio classification model, or MERT, a music understanding model.
   - KID: Kernel inception score
   - KL: KL divergence (softmax over logits)
   - KL_Sigmoid: KL divergence (sigmoid over logits)
@@ -51,6 +51,8 @@ For more information on our evaluation process, please refer to [our paper](http
 
 ## Example
 
+Single-GPU mode:
+
 ```python
 import torch
 from audioldm_eval import EvaluationHelper
@@ -68,12 +70,41 @@ evaluator = EvaluationHelper(16000, device)
 metrics = evaluator.main(
     generation_result_path,
     target_audio_path,
+    backbone="cnn14", # `cnn14` refers to PANNs model, `mert` refers to MERT model
     limit_num=None # If you only intend to evaluate X (int) pairs of data, set limit_num=X
 )
 ```
 
-## Note
+Multi-GPU mode:
 
+```python
+import torch
+from audioldm_eval import EvaluationHelperParallel
+import torch.multiprocessing as mp
+
+generation_result_path = "example/paired"
+target_audio_path = "example/reference"
+
+if __name__ == '__main__':    
+    evaluator = EvaluationHelperParallel(16000, 2) # 2 denotes number of GPUs
+    metrics = evaluator.main(
+        generation_result_path,
+        target_audio_path,
+        backbone="cnn14", # `cnn14` refers to PANNs model, `mert` refers to MERT model
+        limit_num=None # If you only intend to evaluate X (int) pairs of data, set limit_num=X
+    )
+```
+
+You can use `CUDA_VISIBLE_DEVICES` to specify the GPU/GPUs to use.
+
+```shell
+CUDA_VISIBLE_DEVICES=0,1 python3 test.py
+```
+
+## Note
+- Update on 29 Sept 2024:
+  - **MERT inference:** Note that the MERT model is trained on 24 kHz, but the repository inference in either 16 kHz or 32 kHz mode. In both modes, we resample the audio to 24 kHz.
+  - **FAD calculation:** The FAD calculation currently even in the parallel mode will only be done on the first GPU, due to the implementation we currently use.
 - Update on 24 June 2023: 
   - **Issues on model evaluation:** I found the PANNs based Frechet Distance and KL score is not as robust as FAD sometimes. For example, when the generation are all silent audio, the FAD and KL still indicate model perform very well, while FAD and Inception Score (IS) can still reflect the model true bad performance. Sometimes the resample method on audio can significantly affect the FD (+-30) and KL (+-0.4) performance as well.
     - To address this issue, in another branch of this repo ([passt_replace_panns](https://github.com/haoheliu/audioldm_eval/tree/passt_replace_panns)), I change the PANNs model to Passt, which I found to be more robust to resample method and other trival mismatches.

--- a/audioldm_eval/__init__.py
+++ b/audioldm_eval/__init__.py
@@ -3,5 +3,4 @@ from .metrics.isc import calculate_isc
 from .metrics.kid import calculate_kid
 from .metrics.kl import calculate_kl
 from .eval import EvaluationHelper
-
-print("2023 -06 -22")
+from .eval_parallel import EvaluationHelperParallel

--- a/audioldm_eval/eval_parallel.py
+++ b/audioldm_eval/eval_parallel.py
@@ -1,0 +1,340 @@
+import os
+import torch
+import datetime
+import numpy as np
+import torch.multiprocessing as mp
+import torchaudio.transforms as T
+from transformers import Wav2Vec2Processor, AutoModel, Wav2Vec2FeatureExtractor
+from torch.utils.data import DataLoader, DistributedSampler
+from torch.nn.parallel import DistributedDataParallel as DDP
+import torch.distributed as dist
+from audioldm_eval.datasets.load_mel import WaveDataset
+from audioldm_eval.metrics.fad import FrechetAudioDistance
+from audioldm_eval import calculate_fid, calculate_isc, calculate_kid, calculate_kl
+from audioldm_eval.feature_extractors.panns import Cnn14
+from audioldm_eval.audio.tools import save_pickle, load_pickle, write_json, load_json
+from tqdm import tqdm
+
+class EvaluationHelperParallel:
+    def __init__(self, sampling_rate, num_gpus, batch_size=1, backbone="mert") -> None:
+        self.sampling_rate = sampling_rate
+        self.num_gpus = num_gpus
+        self.backbone = backbone
+        self.batch_size = batch_size
+
+    def setup(self, rank, world_size):
+        os.environ['MASTER_ADDR'] = 'localhost'
+        os.environ['MASTER_PORT'] = '12355'
+        dist.init_process_group("nccl", rank=rank, world_size=world_size)
+        torch.cuda.set_device(rank)
+
+    def cleanup(self):
+        dist.destroy_process_group()
+
+    def init_models(self, rank):
+        self.device = torch.device(f"cuda:{rank}")
+        self.frechet = FrechetAudioDistance(use_pca=False, use_activation=False, verbose=True)
+        self.frechet.model = self.frechet.model.to(self.device)
+
+        features_list = ["2048", "logits"]
+        
+        if self.backbone == "mert":
+            self.mel_model = AutoModel.from_pretrained("m-a-p/MERT-v1-95M", trust_remote_code=True)
+            self.processor = Wav2Vec2FeatureExtractor.from_pretrained("m-a-p/MERT-v1-95M",trust_remote_code=True)
+            self.target_sample_rate = self.processor.sampling_rate
+            self.resampler = T.Resample(orig_freq=self.sampling_rate, new_freq=self.target_sample_rate).to(self.device)
+            
+        elif self.backbone == "cnn14":
+            if self.sampling_rate == 16000:
+                self.mel_model = Cnn14(
+                    features_list=features_list,
+                    sample_rate=16000,
+                    window_size=512,
+                    hop_size=160,
+                    mel_bins=64,
+                    fmin=50,
+                    fmax=8000,
+                    classes_num=527,
+                )
+            elif self.sampling_rate == 32000:
+                self.mel_model = Cnn14(
+                    features_list=features_list,
+                    sample_rate=32000,
+                    window_size=1024,
+                    hop_size=320,
+                    mel_bins=64,
+                    fmin=50,
+                    fmax=14000,
+                    classes_num=527,
+                )
+            else:
+                raise ValueError("We only support the evaluation on 16kHz and 32kHz sampling rate.")
+        
+        else:
+            raise ValueError("Backbone not supported")
+
+        self.mel_model = DDP(self.mel_model.to(self.device), device_ids=[rank])
+        self.mel_model.eval()
+
+    def main(self, generate_files_path, groundtruth_path, limit_num=None):
+        mp.spawn(self.run, args=(generate_files_path, groundtruth_path, limit_num), nprocs=self.num_gpus, join=True)
+    
+    def get_featuresdict(self, rank, dataloader):
+        out = None
+        out_meta = {"file_path_": []}
+
+        for waveform, filename in dataloader:
+            try:
+                waveform = waveform.squeeze(1).float().to(self.device)
+
+                with torch.no_grad():
+                    if self.backbone == "mert":
+                        waveform = self.resampler(waveform[0])
+                        mert_input = self.processor(waveform, sampling_rate=self.target_sample_rate, return_tensors="pt").to(self.device)
+                        mert_output = self.mel_model(**mert_input, output_hidden_states=True)
+                        time_reduced_hidden_states = torch.stack(mert_output.hidden_states).squeeze().mean(dim=1)
+                        featuresdict = {"2048": time_reduced_hidden_states, "logits": time_reduced_hidden_states}
+                    elif self.backbone == "cnn14":
+                        featuresdict = self.mel_model(waveform)
+
+                featuresdict = {k: v for k, v in featuresdict.items()}
+
+                if out is None:
+                    out = featuresdict
+                else:
+                    out = {k: torch.cat([out[k], featuresdict[k]], dim=0) for k in out.keys()}
+                
+                out_meta["file_path_"].extend(filename)
+            except Exception as e:
+                print(f"Classifier Inference error on rank {rank}: ", e)
+                continue
+
+        return out, out_meta
+
+    def gather_features(self, featuresdict, metadict):
+        all_features = {}
+        for k, v in featuresdict.items():
+            gathered = [torch.zeros_like(v) for _ in range(self.num_gpus)]
+            dist.all_gather(gathered, v)
+            all_features[k] = torch.cat(gathered, dim=0)
+
+        all_meta = {}
+        for k, v in metadict.items():
+            gathered = [None for _ in range(self.num_gpus)]
+            dist.all_gather_object(gathered, v)
+            all_meta[k] = sum(gathered, [])
+
+        return {**all_features, **all_meta}
+
+    def run(self, rank, generate_files_path, groundtruth_path, limit_num):
+        self.setup(rank, self.num_gpus)
+        self.init_models(rank)
+
+        same_name = self.get_filename_intersection_ratio(generate_files_path, groundtruth_path, limit_num=limit_num)
+
+        metrics = self.calculate_metrics(rank, generate_files_path, groundtruth_path, same_name, limit_num) # recalculate = True
+
+        if rank == 0:
+            print("\n".join((f"{k}: {v:.7f}" for k, v in metrics.items())))
+            json_path = os.path.join(os.path.dirname(generate_files_path), f"{self.get_current_time()}_{os.path.basename(generate_files_path)}.json")
+            write_json(metrics, json_path)
+
+        self.cleanup()
+
+    def calculate_metrics(self, rank, generate_files_path, groundtruth_path, same_name, limit_num=None, calculate_psnr_ssim=False, calculate_lsd=False, recalculate=False):
+        torch.manual_seed(0)
+        num_workers = 6
+
+        output_dataset = WaveDataset(generate_files_path, self.sampling_rate, limit_num=limit_num)
+        result_dataset = WaveDataset(groundtruth_path, self.sampling_rate, limit_num=limit_num)
+
+        output_sampler = DistributedSampler(output_dataset, num_replicas=self.num_gpus, rank=rank)
+        result_sampler = DistributedSampler(result_dataset, num_replicas=self.num_gpus, rank=rank)
+
+        outputloader = DataLoader(
+            output_dataset,
+            batch_size=self.batch_size,
+            sampler=output_sampler,
+            num_workers=num_workers,
+        )
+
+        resultloader = DataLoader(
+            result_dataset,
+            batch_size=self.batch_size,
+            sampler=result_sampler,
+            num_workers=num_workers,
+        )
+
+        out = {}
+        if rank == 0:
+            if(recalculate): 
+                print("Calculate FAD score from scratch")
+            fad_score = self.frechet.score(generate_files_path, groundtruth_path, limit_num=limit_num, recalculate=recalculate)
+            out.update(fad_score)
+            print("FAD: %s" % fad_score)
+            
+        cache_path = generate_files_path + "classifier_logits_feature_cache.pkl"
+        if os.path.exists(cache_path) and not recalculate:
+            print("reload", cache_path)
+            all_featuresdict_1 = load_pickle(cache_path)
+        else:
+            print(f"Extracting features from {generate_files_path}.")
+            featuresdict_1, metadict_1 = self.get_featuresdict(rank, outputloader)
+            all_featuresdict_1 = self.gather_features(featuresdict_1, metadict_1)
+            if rank == 0: 
+                save_pickle(all_featuresdict_1, cache_path)
+
+        cache_path = groundtruth_path + "classifier_logits_feature_cache.pkl"
+        if os.path.exists(cache_path) and not recalculate:
+            print("reload", cache_path)
+            all_featuresdict_2 = load_pickle(cache_path)
+        else:
+            print(f"Extracting features from {groundtruth_path}.")
+            featuresdict_2, metadict_2 = self.get_featuresdict(rank, resultloader)
+            all_featuresdict_2 = self.gather_features(featuresdict_2, metadict_2)
+            if rank == 0:  
+                save_pickle(all_featuresdict_2, cache_path)
+
+        if rank == 0:
+            for k, v in all_featuresdict_1.items():
+                if isinstance(v, torch.Tensor):
+                    all_featuresdict_1[k] = v.cpu()
+            for k, v in all_featuresdict_2.items():
+                if isinstance(v, torch.Tensor):
+                    all_featuresdict_2[k] = v.cpu()
+                
+            metric_kl, _, _ = calculate_kl(all_featuresdict_1, all_featuresdict_2, "logits", same_name)
+            out.update(metric_kl)
+
+            metric_isc = calculate_isc(all_featuresdict_1, feat_layer_name="logits", splits=10, samples_shuffle=True, rng_seed=2020)
+            out.update(metric_isc)
+
+            if "2048" in all_featuresdict_1.keys() and "2048" in all_featuresdict_2.keys():
+                metric_fid = calculate_fid(all_featuresdict_1, all_featuresdict_2, feat_layer_name="2048")
+                out.update(metric_fid)
+                
+            if(calculate_psnr_ssim or calculate_lsd):
+                pairedloader = DataLoader(
+                    MelPairedDataset(
+                        generate_files_path,
+                        groundtruth_path,
+                        self._stft,
+                        self.sampling_rate,
+                        self.fbin_mean,
+                        self.fbin_std,
+                        limit_num=limit_num,
+                    ),
+                    batch_size=self.batch_size,
+                    sampler=None,
+                    num_workers=16,
+                )
+                
+            if(calculate_lsd):
+                metric_lsd = self.calculate_lsd(pairedloader, same_name=same_name)
+                out.update(metric_lsd)
+
+            if(calculate_psnr_ssim):
+                metric_psnr_ssim = self.calculate_psnr_ssim(pairedloader, same_name=same_name)
+                out.update(metric_psnr_ssim)
+
+        dist.barrier()
+        return out
+    
+    def file_init_check(self, dir):
+        assert os.path.exists(dir), "The path does not exist %s" % dir
+        assert len(os.listdir(dir)) > 1, "There is no files in %s" % dir
+
+    def get_filename_intersection_ratio(
+        self, dir1, dir2, threshold=0.99, limit_num=None
+    ):
+        self.datalist1 = [os.path.join(dir1, x) for x in os.listdir(dir1)]
+        self.datalist1 = sorted(self.datalist1)
+
+        self.datalist2 = [os.path.join(dir2, x) for x in os.listdir(dir2)]
+        self.datalist2 = sorted(self.datalist2)
+
+        data_dict1 = {os.path.basename(x): x for x in self.datalist1}
+        data_dict2 = {os.path.basename(x): x for x in self.datalist2}
+
+        keyset1 = set(data_dict1.keys())
+        keyset2 = set(data_dict2.keys())
+
+        intersect_keys = keyset1.intersection(keyset2)
+        if (
+            len(intersect_keys) / len(keyset1) > threshold
+            and len(intersect_keys) / len(keyset2) > threshold
+        ):
+            print(
+                "+Two path have %s intersection files out of total %s & %s files. Processing two folder with same_name=True"
+                % (len(intersect_keys), len(keyset1), len(keyset2))
+            )
+            return True
+        else:
+            print(
+                "-Two path have %s intersection files out of total %s & %s files. Processing two folder with same_name=False"
+                % (len(intersect_keys), len(keyset1), len(keyset2))
+            )
+            return False
+
+    def calculate_lsd(self, pairedloader, same_name=True, time_offset=160 * 7):
+        if same_name == False:
+            return {
+                "lsd": -1,
+                "ssim_stft": -1,
+            }
+        print("Calculating LSD using a time offset of %s ..." % time_offset)
+        lsd_avg = []
+        ssim_stft_avg = []
+        for _, _, filename, (audio1, audio2) in tqdm(pairedloader):
+            audio1 = audio1.cpu().numpy()[0, 0]
+            audio2 = audio2.cpu().numpy()[0, 0]
+
+            # If you use HIFIGAN (verified on 2023-01-12), you need seven frames' offset
+            audio1 = audio1[time_offset:]
+
+            audio1 = audio1 - np.mean(audio1)
+            audio2 = audio2 - np.mean(audio2)
+
+            audio1 = audio1 / np.max(np.abs(audio1))
+            audio2 = audio2 / np.max(np.abs(audio2))
+
+            min_len = min(audio1.shape[0], audio2.shape[0])
+
+            audio1, audio2 = audio1[:min_len], audio2[:min_len]
+
+            result = self.lsd(audio1, audio2)
+
+            lsd_avg.append(result["lsd"])
+            ssim_stft_avg.append(result["ssim"])
+
+        return {"lsd": np.mean(lsd_avg), "ssim_stft": np.mean(ssim_stft_avg)}
+
+    def lsd(self, audio1, audio2):
+        result = self.lsd_metric.evaluation(audio1, audio2, None)
+        return result
+    
+    def calculate_psnr_ssim(self, pairedloader, same_name=True):
+        if same_name == False:
+            return {"psnr": -1, "ssim": -1}
+        psnr_avg = []
+        ssim_avg = []
+        for mel_gen, mel_target, filename, _ in tqdm(pairedloader):
+            mel_gen = mel_gen.cpu().numpy()[0]
+            mel_target = mel_target.cpu().numpy()[0]
+            psnrval = psnr(mel_gen, mel_target)
+            if np.isinf(psnrval):
+                print("Infinite value encountered in psnr %s " % filename)
+                continue
+            psnr_avg.append(psnrval)
+            data_range = max(np.max(mel_gen), np.max(mel_target)) - min(np.min(mel_gen), np.min(mel_target))
+            ssim_avg.append(ssim(mel_gen, mel_target, data_range=data_range))
+        return {"psnr": np.mean(psnr_avg), "ssim": np.mean(ssim_avg)}
+    
+    def get_current_time(self):
+        now = datetime.datetime.now()
+        return now.strftime("%Y-%m-%d-%H:%M:%S")
+    
+    def sample_from(self, samples, number_to_use):
+        assert samples.shape[0] >= number_to_use
+        rand_order = np.random.permutation(samples.shape[0])
+        return samples[rand_order[: samples.shape[0]], :]

--- a/audioldm_eval/metrics/fid.py
+++ b/audioldm_eval/metrics/fid.py
@@ -22,7 +22,7 @@ def calculate_fid(
         "sigma": np.cov(features_2.numpy(), rowvar=False),
     }
 
-    print("Computing Frechet Distance (PANNs)")
+    print("Computing Frechet Distance")
 
     mu1, sigma1 = stat_1["mu"], stat_1["sigma"]
     mu2, sigma2 = stat_2["mu"], stat_2["sigma"]

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ VERSION = "0.0.5"
 REQUIRED = [
     "torch>=1.11.0",
     "torchaudio",
+    "transformers",
     "scikit-image",
     "torchlibrosa",
     "absl-py",

--- a/test.py
+++ b/test.py
@@ -1,11 +1,14 @@
 import torch
-from audioldm_eval import EvaluationHelper
+from audioldm_eval import EvaluationHelper, EvaluationHelperParallel
+import torch.multiprocessing as mp
 
 device = torch.device(f"cuda:{0}")
 
 generation_result_path = "example/paired"
 # generation_result_path = "example/unpaired"
 target_audio_path = "example/reference"
+
+## Single GPU
 
 evaluator = EvaluationHelper(16000, device)
 
@@ -14,3 +17,12 @@ metrics = evaluator.main(
     generation_result_path,
     target_audio_path,
 )
+
+## Multiple GPUs
+
+if __name__ == '__main__':    
+    evaluator = EvaluationHelperParallel(16000, 2)
+    metrics = evaluator.main(
+        generation_result_path,
+        target_audio_path,
+    )


### PR DESCRIPTION
- Adding additional MERT backbone for music evaluation tasks.
- Adding a multi-GPU evaluation mode, realized by PyTorch DDP.
	- A caveat: since the VGGish implemented called in this repo would only accept a numpy.ndarray waveform sample in, the frechet audio distance would be calculated on the first available GPU only.

The added changes have been tested through the test samples generate by this repo. Note that the results are extremely close, but not exactly the same. 

PANN backbone:
| Metric | Single GPU | Multiple GPUs |
|--------|------------|---------------|
| Fréchet Distance | 76.5592910152047 | 76.55929104668417 |
| Fréchet Audio Distance | 25.13933342756768 | 25.13933342756768 |
| KL Divergence (Sigmoid) | 4.942387580871582 | 4.942387580871582 |
| KL Divergence (Softmax) | 5.392766952514648 | 5.392767429351807 |
| Inception Score (Mean) | 1.4111682664276006 | 1.3807413446235108 |
| Inception Score (Std) | 0.2100466806269512 | 0.16963117700578514 |

MERT backbone:
| Metric | Single GPU | Multiple GPUs |
|--------|------------|---------------|
| Fréchet Distance | 35.53496529798653 | 35.534967212472644 |
| Fréchet Audio Distance | 25.13933342756768 | 25.13933342756768 |
| KL Divergence (Sigmoid) | 2.0398805141448975 | 2.0328383445739746 |
| KL Divergence (Softmax) | 0.021201787516474724 | 0.025442462414503098 |
| Inception Score (Mean) | 1.017859189575241 | 1.0178318327079956 |
| Inception Score (Std) | 0.0009513526838024663 | 0.0011269906062056378 |

This may be due to NCCL communications' non-deterministic nature, see https://github.com/NVIDIA/nccl/issues/157. As the difference is quite small, the users can choose for themselves in if they want to use the parallel calculation, which may save time if the evaluation set is large.